### PR TITLE
Fixes position as float problem for Opera

### DIFF
--- a/web-app/js/application.js
+++ b/web-app/js/application.js
@@ -172,11 +172,10 @@ function handleSpectroClick(e,spectrogramId) {
 	var beltPosition = jQuery('#acoustic_Spectrogram-'+spectrogramId).parents('.belt').position(); //parent div of panel divs	
 	var panelPosition = jQuery('#acoustic_Spectrogram-'+spectrogramId).parents('.panel').position(); //parent div of image
 	var imageLeftPosition = panelPosition.left + containerPosition.left + beltPosition.left;
-	var clickLeftPosition = e.clientX - imageLeftPosition;	
+	var clickLeftPosition = Math.round(e.clientX - imageLeftPosition);
 	
 	loadDetails(clickLeftPosition,spectrogramId);
-	
-	//e.preventDefault(); causes IE bug
+
 	return false;
 }
 


### PR DESCRIPTION
Fix for problem clicking on spectrograph

http://api.jquery.com/position/
_The number returned by dimensions-related APIs, including .position(), may be fractional in some cases. Code should not assume it is an integer. Also, dimensions may be incorrect when the page is zoomed by the user; browsers do not expose an API to detect this condition._
